### PR TITLE
fix 32 bit build target

### DIFF
--- a/src/traits/dispatcher.rs
+++ b/src/traits/dispatcher.rs
@@ -309,6 +309,7 @@ impl<T: Radixable<isize>> Dispatcher<T, isize> for isize {
     fn voracious_stable_sort(&self, arr: &mut [T]) {
         lsd_stable_radixsort(arr, 8);
     }
+    #[cfg(feature = "voracious_multithread")]
     fn voracious_mt_sort(&self, arr: &mut [T], thread_n: usize) {
         if arr.len() <= 256 {
             arr.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
@@ -576,6 +577,7 @@ impl<T: Radixable<usize>> Dispatcher<T, usize> for usize {
     fn voracious_stable_sort(&self, arr: &mut [T]) {
         lsd_stable_radixsort(arr, 8);
     }
+    #[cfg(feature = "voracious_multithread")]
     fn voracious_mt_sort(&self, arr: &mut [T], thread_n: usize) {
         if arr.len() <= 256 {
             arr.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());

--- a/src/types/isize.rs
+++ b/src/types/isize.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "voracious_multithread")]
 use rayon::slice::ParallelSliceMut;
 
+use super::super::sorts::rollercoaster_sort::rollercoaster_sort_heu;
+use super::super::sorts::lsd_sort::lsd_radixsort_heu;
 #[cfg(feature = "voracious_multithread")]
 use super::super::sorts::peeka_sort::peeka_sort;
 use super::super::sorts::rollercoaster_sort::rollercoaster_sort;

--- a/src/types/usize.rs
+++ b/src/types/usize.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "voracious_multithread")]
 use rayon::slice::ParallelSliceMut;
 
+use super::super::sorts::lsd_sort::lsd_radixsort_heu;
 use super::super::sorts::dlsd_sort::dlsd_radixsort;
 #[cfg(feature = "voracious_multithread")]
 use super::super::sorts::peeka_sort::peeka_sort;


### PR DESCRIPTION
This fixes two missing #[cfg(feature = "voracious_multithread")] guards, as well as some missing imports on targets other than 64 bit.

(Compilation for wasm32-unknown-unknown previously failed.)